### PR TITLE
Update PEP8 so that all errors of the same type are outputted 

### DIFF
--- a/jenkins-code-analysis.cfg
+++ b/jenkins-code-analysis.cfg
@@ -56,7 +56,7 @@ input = inline:
     for pkg in $PACKAGES
     do
         echo "Analyse $pkg"
-        find -L ${buildout:directory}/$pkg -regex ".*\.py" | xargs -r bin/pep8-bin >> ${buildout:jenkins-directory}/pep8.log.tmp
+        find -L ${buildout:directory}/$pkg -regex ".*\.py" | xargs -r bin/pep8-bin -r >> ${buildout:jenkins-directory}/pep8.log.tmp
     done
     cat ${buildout:jenkins-directory}/pep8.log.tmp|sed 's:${buildout:directory}/::' > ${buildout:jenkins-directory}/pep8.log
     echo "Finished."


### PR DESCRIPTION
Added `-r` argument to pep8-bin.
