### PR TITLE
Split the xmllint calling errors from the analysed errors 

### DIFF
--- a/jenkins-code-analysis.cfg
+++ b/jenkins-code-analysis.cfg
@@ -251,13 +251,13 @@ input = inline:
     for pkg in $PACKAGES
     do
         echo "Analyse $pkg"
-        find -L $pkg -regex ".*\.[cz]?pt" | xargs xmllint --noout > ${buildout:jenkins-directory}/xmllint.log 2>&1
+        find -L $pkg -regex ".*\.[cz]?pt" | xargs xmllint --noout 2>> ${buildout:jenkins-directory}/xmllint.log >> ${buildout:jenkins-directory}/xmllint-errors.log
     done
-    if [ -s ${buildout:jenkins-directory}/xmllint.log ]; then
-      echo "Errors were found:"
-      cat ${buildout:jenkins-directory}/xmllint.log
-      echo "Errors were written to xmllint.log"
-      exit 1;
+    if [ -s ${buildout:jenkins-directory}/xmllint-errors.log ]; then
+        echo "Errors were found:"
+        cat ${buildout:jenkins-directory}/xmllint-errors.log
+        echo "Errors were written to xmllint-errors.log"
+        exit 1;
     else
       echo "No errors found"
     fi


### PR DESCRIPTION
Right now the xmllint script outputs both the errors from calling xmllint itself with the ones that xmllint finds while doing its job.

This patch splits this in two different files: one for errors found by xmllint and one for errors calling xmllint itself
