### PR TITLE
jenkins-code-analysis-flake8 unable to run due to invalid path

### DIFF
--- a/jenkins-code-analysis.cfg
+++ b/jenkins-code-analysis.cfg
@@ -112,7 +112,7 @@ recipe = collective.recipe.template
 url = https://raw.github.com/plone/buildout.jenkins/master/templates/code-analysis.sh
 output = ${buildout:directory}/bin/jenkins-code-analysis-flake8
 title = Flake8
-bin = ${buildout:directory}bin/flake8
+bin = ${buildout:directory}/bin/flake8
 log = flake8.log
 before =
 analyse = $(find -L ${buildout:directory}/$pkg -regex ".*\.py" | xargs -r ${:bin} --ignore=${buildout:ignore-pep8} >> ${buildout:jenkins-directory}/flake8.log.tmp)


### PR DESCRIPTION
Added missing directory seperator for jenkins-code-analysis-flake8 runner.